### PR TITLE
Updates to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pacman -Syu --noconfirm gcc make autoconf automake cmake ninja boost libtool
 ADD . /bitshares-2
 WORKDIR /bitshares-2
 RUN cmake -G Ninja -DCMAKE_BUILD_TYPE=Release .
-RUN ninja witness_node
+RUN ninja witness_node || ninja -j 1 witness_node
 
 RUN mkdir /data_dir
 ADD docker/default_config.ini /default_config.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
+# This will build the witness_node in a docker image. Make sure you've already
+# checked out the submodules before building.
+
 FROM l3iggs/archlinux:latest
 MAINTAINER Nathan Hourt <nathan@followmyvote.com>
 
 RUN pacman -Syu --noconfirm gcc make autoconf automake cmake ninja boost libtool git
 
-RUN git clone https://github.com/bitshares/bitshares-2
+ADD . /bitshares-2
 WORKDIR /bitshares-2
-RUN git submodule update --init --recursive
-RUN cmake -G Ninja .
+RUN cmake -G Ninja -DCMAKE_BUILD_TYPE=Release .
 RUN ninja witness_node
 
 RUN mkdir /data_dir
-ADD default_config.ini /default_config.ini
-ADD launch /launch
+ADD docker/default_config.ini /default_config.ini
+ADD docker/launch /launch
 RUN chmod a+x /launch
 VOLUME /data_dir
 

--- a/docker/launch
+++ b/docker/launch
@@ -1,4 +1,11 @@
 #!/bin/bash
 
 [ -e /data_dir/config.ini ] || cp /default_config.ini /data_dir/config.ini
-/bitshares-2/programs/witness_node/witness_node --data-dir /data_dir
+
+[ -e /data_dir/pre_exec ] && bash /data_dir/pre_exec
+if [ -e /data_dir/extra_args ]; then
+   /bitshares-2/programs/witness_node/witness_node --data-dir /data_dir `cat /data_dir/extra_args`
+else
+   /bitshares-2/programs/witness_node/witness_node --data-dir /data_dir
+fi
+[ -e /data_dir/post_exec ] && bash /data_dir/post_exec


### PR DESCRIPTION
- Build from repo rather than cloning inside the image
- Update launch script to support pre- and post-exec scripts, as well as arbitrary extra command line arguments to the witness node