### PR TITLE
Dockerfile fix: export 8090, not 8091

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ ADD docker/launch /launch
 RUN chmod a+x /launch
 VOLUME /data_dir
 
-EXPOSE 8091 9090
+EXPOSE 8090 9090
 
 ENTRYPOINT ["/launch"]


### PR DESCRIPTION
The default config opens a RPC server on 8090; the correct port to expose is 8090. 8091 was a typo